### PR TITLE
Prevent dropdown menu outside the screen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,17 +17,17 @@ export default class extends Controller {
   }
 
   toggle ({
-    target
+    target: button
   }: {
     target: HTMLInputElement
   }): void {
     this.toggleTransition()
-    this.updateMenuPosition(target)
+    this.updateMenuPosition(button)
   }
 
-  updateMenuPosition (target: HTMLInputElement): void {
+  updateMenuPosition (button: HTMLInputElement): void {
     const menuRect = this.menuTarget.getBoundingClientRect()
-    const buttonRect = target.getBoundingClientRect()
+    const buttonRect = button.getBoundingClientRect()
 
     if(!this.menuTarget.classList.contains('enter-active')) return;
 
@@ -36,10 +36,10 @@ export default class extends Controller {
       return;
     };
 
-    this.hang(menuRect, target.offsetHeight)
+    this.hang(menuRect, button.offsetHeight)
   }
 
-  hang (menuRect: DOMRect, menuOffsetHeight: number): void {
+  hang (menuRect: DOMRect, buttonOffsetHeight: number): void {
     if (menuRect.left < 0) {
       this.hangLeft()
     }
@@ -48,10 +48,10 @@ export default class extends Controller {
     }
 
     if (menuRect.top < 0) {
-      this.hangTop(menuOffsetHeight)
+      this.hangTop(buttonOffsetHeight)
     }
     else if (menuRect.bottom > window.innerHeight) {
-      this.hangBottom(menuOffsetHeight)
+      this.hangBottom(buttonOffsetHeight)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ export default class extends Controller {
 
   connect (): void {
     useTransition(this, {
-      element: this.menuTarget
+      element: this.menuTarget,
+      enterActive: 'enter-active',
     })
   }
 
@@ -27,6 +28,12 @@ export default class extends Controller {
   updateMenuPosition (menuOffsetHeight: number): void {
     const menuRect = this.menuTarget.getBoundingClientRect()
 
+    if(!this.menuTarget.classList.contains('enter-active')) return;
+
+    this.hang(menuRect, menuOffsetHeight)
+  }
+
+  hang (menuRect: DOMRect, menuOffsetHeight: number): void {
     if (menuRect.left < 0) {
       this.hangLeft()
     }
@@ -43,18 +50,21 @@ export default class extends Controller {
   }
 
   hangLeft (): void {
-    this.menuTarget.classList.add('left-0')
-    this.menuTarget.classList.remove('right-0')
+    this.menuTarget.style.left = '0px'
+    this.menuTarget.style.right = 'auto'
   }
+
   hangRight (): void {
-    this.menuTarget.classList.add('right-0')
-    this.menuTarget.classList.remove('left-0')
+    this.menuTarget.style.right = '0px'
+    this.menuTarget.style.left = 'auto'
   }
+
   hangBottom (buttonHeight: number): void {
-    this.menuTarget.style.bottom = `${buttonHeight + 10}px`;
+    this.menuTarget.style.bottom = `${buttonHeight + 10}px`
   }
+
   hangTop (buttonHeight: number): void {
-    this.menuTarget.style.top = `${buttonHeight + 10}px`;
+    this.menuTarget.style.top = `${buttonHeight + 10}px`
   }
 
   hide (event: Event): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,15 +22,21 @@ export default class extends Controller {
     target: HTMLInputElement
   }): void {
     this.toggleTransition()
-    this.updateMenuPosition(target.offsetHeight)
+    this.updateMenuPosition(target)
   }
 
-  updateMenuPosition (menuOffsetHeight: number): void {
+  updateMenuPosition (target: HTMLInputElement): void {
     const menuRect = this.menuTarget.getBoundingClientRect()
+    const buttonRect = target.getBoundingClientRect()
 
     if(!this.menuTarget.classList.contains('enter-active')) return;
 
-    this.hang(menuRect, menuOffsetHeight)
+    if (buttonRect.right <= menuRect.width) {
+      this.hangLeft();
+      return;
+    };
+
+    this.hang(menuRect, target.offsetHeight)
   }
 
   hang (menuRect: DOMRect, menuOffsetHeight: number): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,51 @@ export default class extends Controller {
     })
   }
 
-  toggle (): void {
+  toggle ({
+    target
+  }: {
+    target: HTMLInputElement
+  }): void {
     this.toggleTransition()
+    this.updateMenuPosition(target.offsetHeight)
+  }
+
+  updateMenuPosition (menuOffsetHeight: number): void {
+    const menuRect = this.menuTarget.getBoundingClientRect()
+
+    if (menuRect.left < 0) {
+      this.hangLeft()
+    }
+    else if (menuRect.right > window.innerWidth) {
+      this.hangRight()
+    }
+
+    if (menuRect.top < 0) {
+      this.hangTop(menuOffsetHeight)
+    }
+    else if (menuRect.bottom > window.innerHeight) {
+      this.hangBottom(menuOffsetHeight)
+    }
+  }
+
+  hangLeft (): void {
+    this.menuTarget.classList.add('left-0')
+    this.menuTarget.classList.remove('right-0')
+  }
+  hangRight (): void {
+    this.menuTarget.classList.add('right-0')
+    this.menuTarget.classList.remove('left-0')
+  }
+  hangBottom (buttonHeight: number): void {
+    this.menuTarget.style.bottom = `${buttonHeight + 10}px`;
+  }
+  hangTop (buttonHeight: number): void {
+    this.menuTarget.style.top = `${buttonHeight + 10}px`;
   }
 
   hide (event: Event): void {
-    // @ts-ignore
-    if (!this.element.contains(event.target) && !this.menuTarget.classList.contains('hidden')) {
+    const node = event.target as Node
+    if (!this.element.contains(node) && !this.menuTarget.classList.contains('hidden')) {
       this.leave()
     }
   }


### PR DESCRIPTION
Prevents the menu from leaving the screen, so that it always remains visible.

This also allows the menu to be used in the navigation bars at the bottom of the screen, with the menu displayed at the top and not off the screen, simplifying responsiveness and preventing unwanted behavior.

**Video**: Test on preview url:
https://share.cleanshot.com/kqJLh2NR